### PR TITLE
카테고리 색상 정보 추가, 사용자 선호 카테고리 로직 구현

### DIFF
--- a/src/main/java/com/devita/common/oauth/CustomOAuth2UserService.java
+++ b/src/main/java/com/devita/common/oauth/CustomOAuth2UserService.java
@@ -73,9 +73,12 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
 
     private void createDefaultCategories(Long userId) {
         String[] defaultCategories = {"일반", "일일 미션", "자율 미션"};
-        for (String categoryName : defaultCategories) {
+        String[] defaultColors = {"#000000", "#FFC0CB", "#87CEEB"}; // 검정, 분홍, 하늘
+
+        for (int i = 0; i < defaultCategories.length; i++) {
             CategoryReqDTO categoryReqDto = new CategoryReqDTO();
-            categoryReqDto.setName(categoryName);
+            categoryReqDto.setName(defaultCategories[i]);
+            categoryReqDto.setColor(defaultColors[i]);
             categoryService.createCategory(userId, categoryReqDto);
         }
     }

--- a/src/main/java/com/devita/common/oauth/OAuth2LoginSuccessHandler.java
+++ b/src/main/java/com/devita/common/oauth/OAuth2LoginSuccessHandler.java
@@ -43,7 +43,7 @@ public class OAuth2LoginSuccessHandler extends SimpleUrlAuthenticationSuccessHan
         );
 
         jwtTokenProvider.createRefreshToken(response, user.getId());
-
+        System.out.println(jwtTokenProvider.createAccessToken(user.getId()));
         getRedirectStrategy().sendRedirect(request, response,  redirectUrl);
     }
 }

--- a/src/main/java/com/devita/domain/category/domain/Category.java
+++ b/src/main/java/com/devita/domain/category/domain/Category.java
@@ -28,6 +28,8 @@ public class Category {
     private User user;
 
     private String name;
+
+    private String color;
     @CreatedDate
     private String createdAt;
     @LastModifiedDate
@@ -36,9 +38,10 @@ public class Category {
     @OneToMany(mappedBy = "category", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Todo> todos;
 
-    public Category(User user, String name){
+    public Category(User user, String name, String color){
         this.user = user;
         this.name = name;
+        this.color = color;
         todos = new ArrayList<>();
     }
 

--- a/src/main/java/com/devita/domain/category/dto/CategoryReqDTO.java
+++ b/src/main/java/com/devita/domain/category/dto/CategoryReqDTO.java
@@ -5,4 +5,5 @@ import lombok.Data;
 @Data
 public class CategoryReqDTO {
     private String name;
+    private String color;
 }

--- a/src/main/java/com/devita/domain/category/dto/CategoryResDTO.java
+++ b/src/main/java/com/devita/domain/category/dto/CategoryResDTO.java
@@ -6,4 +6,5 @@ import lombok.Data;
 public class CategoryResDTO {
     private Long id;
     private String name;
+    private String color;
 }

--- a/src/main/java/com/devita/domain/category/service/CategoryService.java
+++ b/src/main/java/com/devita/domain/category/service/CategoryService.java
@@ -26,9 +26,7 @@ public class CategoryService {
     public Category createCategory(Long userId, CategoryReqDTO categoryReqDto) {
         User user = userRepository.findById(userId).orElseThrow();
 
-        Category category = new Category();
-        category.setUser(user);
-        category.setName(categoryReqDto.getName());
+        Category category = new Category(user, categoryReqDto.getName(), categoryReqDto.getColor());
 
         return categoryRepository.save(category);
     }
@@ -50,6 +48,7 @@ public class CategoryService {
         }
 
         category.setName(categoryReqDto.getName());
+        category.setColor(categoryReqDto.getColor());
 
         return categoryRepository.save(category);
     }

--- a/src/main/java/com/devita/domain/todo/dto/CalenderDTO.java
+++ b/src/main/java/com/devita/domain/todo/dto/CalenderDTO.java
@@ -10,7 +10,7 @@ public class CalenderDTO {
     private Long todoId;
     private Long categoryId;
     private String title;
-    private String status;
+    private Boolean status;
     private LocalDate date;
 
 
@@ -19,6 +19,7 @@ public class CalenderDTO {
         dto.setTodoId(todo.getId());
         dto.setCategoryId(todo.getCategory().getId());
         dto.setTitle(todo.getTitle());
+        dto.setStatus(todo.getStatus());
         dto.setDate(todo.getDate());
 
         return dto;

--- a/src/main/java/com/devita/domain/user/api/UserController.java
+++ b/src/main/java/com/devita/domain/user/api/UserController.java
@@ -1,0 +1,28 @@
+package com.devita.domain.user.api;
+
+import com.devita.common.response.ApiResponse;
+import com.devita.domain.user.dto.PreferredCategoryRequest;
+import com.devita.domain.user.dto.PreferredCategoryResponse;
+import com.devita.domain.user.service.UserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/users")
+public class UserController {
+    private final UserService userService;
+
+    @PutMapping("/me/preferred-categories")
+    public ApiResponse<Void> updatePreferredCategories(@AuthenticationPrincipal Long userId, @RequestBody PreferredCategoryRequest request) {
+        userService.updatePreferredCategories(userId, request);
+        return ApiResponse.success(null);
+    }
+
+    @GetMapping("/me/preferred-categories")
+    public ApiResponse<PreferredCategoryResponse> getPreferredCategories(@AuthenticationPrincipal Long userId) {
+        return ApiResponse.success(userService.getPreferredCategories(userId));
+    }
+}

--- a/src/main/java/com/devita/domain/user/domain/PreferredCategory.java
+++ b/src/main/java/com/devita/domain/user/domain/PreferredCategory.java
@@ -1,0 +1,17 @@
+package com.devita.domain.user.domain;
+
+public enum PreferredCategory {
+    DATA_STRUCTURE,
+    ALGORITHM,
+    COMPUTER_ARCHITECTURE,
+    NETWORK,
+    OPERATING_SYSTEM,
+    DATABASE,
+    JAVA,
+    JAVASCRIPT,
+    PYTHON,
+    SPRING,
+    REACT,
+    PYTORCH,
+    DOCKER
+}

--- a/src/main/java/com/devita/domain/user/domain/User.java
+++ b/src/main/java/com/devita/domain/user/domain/User.java
@@ -11,6 +11,7 @@ import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.List;
 
 @Entity
@@ -40,6 +41,15 @@ public class User {
     @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Category> categories;
 
+    @ElementCollection
+    @CollectionTable(
+            name = "user_preferred_categories",
+            joinColumns = @JoinColumn(name = "user_id")
+    )
+    @Enumerated(EnumType.STRING)
+    @Column(name = "category_name")
+    private List<PreferredCategory> preferredCategories = new ArrayList<>();
+
     private String profileImage;
 
     @CreatedDate
@@ -59,5 +69,10 @@ public class User {
 
     public void updateNickname(String nickname) {
         this.nickname = nickname;
+    }
+
+    public void updatePreferredCategories(List<PreferredCategory> categories) {
+        this.preferredCategories.clear();
+        this.preferredCategories.addAll(categories);
     }
 }

--- a/src/main/java/com/devita/domain/user/dto/PreferredCategoryRequest.java
+++ b/src/main/java/com/devita/domain/user/dto/PreferredCategoryRequest.java
@@ -1,0 +1,11 @@
+package com.devita.domain.user.dto;
+
+import com.devita.domain.user.domain.PreferredCategory;
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+public class PreferredCategoryRequest {
+    private List<PreferredCategory> categories;
+}

--- a/src/main/java/com/devita/domain/user/dto/PreferredCategoryResponse.java
+++ b/src/main/java/com/devita/domain/user/dto/PreferredCategoryResponse.java
@@ -1,0 +1,14 @@
+package com.devita.domain.user.dto;
+
+import com.devita.domain.user.domain.PreferredCategory;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+@AllArgsConstructor
+public class PreferredCategoryResponse {
+    private List<PreferredCategory> categories;
+
+}

--- a/src/main/java/com/devita/domain/user/service/UserService.java
+++ b/src/main/java/com/devita/domain/user/service/UserService.java
@@ -1,0 +1,34 @@
+package com.devita.domain.user.service;
+
+import com.devita.common.exception.ErrorCode;
+import com.devita.common.exception.ResourceNotFoundException;
+import com.devita.domain.user.domain.User;
+import com.devita.domain.user.dto.PreferredCategoryRequest;
+import com.devita.domain.user.dto.PreferredCategoryResponse;
+import com.devita.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class UserService {
+    private final UserRepository userRepository;
+
+    @Transactional
+    public void updatePreferredCategories(Long userId, PreferredCategoryRequest request) {
+        User user = getUserById(userId);
+        user.updatePreferredCategories(request.getCategories());
+    }
+
+    public PreferredCategoryResponse getPreferredCategories(Long userId) {
+        User user = getUserById(userId);
+        return new PreferredCategoryResponse(user.getPreferredCategories());
+    }
+
+    private User getUserById(Long userId) {
+        return userRepository.findById(userId)
+                .orElseThrow(() -> new ResourceNotFoundException(ErrorCode.USER_NOT_FOUND));
+    }
+}


### PR DESCRIPTION
- 사용자 선호 카테고리

```python
    DATA_STRUCTURE,
    ALGORITHM,
    COMPUTER_ARCHITECTURE,
    NETWORK,
    OPERATING_SYSTEM,
    DATABASE,
    
    JAVA,
    JAVASCRIPT,
    PYTHON,
    
    SPRING,
    REACT,
    PYTORCH,
    
    DOCKER
```

- 사용자 선호 카테고리 넣기

```python
@PUT : /api/v1/users/me/preferred-categories

req:
{
  "categories": ["JAVA", "SPRING"]
}

res:

```

- 조회하기

```python
@GET : /api/v1/users/me/preferred-categories

req:

res:
{
  "categories": ["JAVA", "SPRING"]
}
```

### 사용자 카테고리 생성이나 수정 시 색 정보도 함께 줘야함

- req

```python
기존 req:
{
  "name": "식습관"
}

수정 req:
{
  "name": "식습관"
  "color": "#FFFFFF"
}
```

- res

```python
기존 res:
{
	"id": 4
  "name": "식습관"
}

수정 res:
{
	"id": 4
  "name": "식습관"
  "color": "#FFFFFF"
}
```